### PR TITLE
fix: 修复因 js-beautify cdn 链接已丢失，导致项目运行报错问题。添加 pluginsConfig.js 文件，统一管理 cdn 路径。

### DIFF
--- a/src/utils/loadBeautifier.js
+++ b/src/utils/loadBeautifier.js
@@ -1,9 +1,11 @@
 import loadScript from './loadScript'
 import ELEMENT from 'element-ui'
+import pluginsConfig from './pluginsConfig'
 
 let beautifierObj
 
 export default function loadBeautifier(cb) {
+  const { beautifierUrl } = pluginsConfig
   if (beautifierObj) {
     cb(beautifierObj)
     return
@@ -17,7 +19,7 @@ export default function loadBeautifier(cb) {
     background: 'rgba(255, 255, 255, 0.5)'
   })
 
-  loadScript('https://lib.baomitu.com/js-beautify/1.10.2/beautifier.min.js', () => {
+  loadScript(beautifierUrl, () => {
     loading.close()
     // eslint-disable-next-line no-undef
     beautifierObj = beautifier

--- a/src/utils/loadMonaco.js
+++ b/src/utils/loadMonaco.js
@@ -1,5 +1,6 @@
 import { loadScriptQueue } from './loadScript'
 import ELEMENT from 'element-ui'
+import pluginsConfig from './pluginsConfig'
 
 // monaco-editor单例
 let monacoEidtor
@@ -14,7 +15,7 @@ export default function loadMonaco(cb) {
     return
   }
 
-  const vs = 'https://lib.baomitu.com/monaco-editor/0.19.3/min/vs'
+  const { monacoEditorUrl: vs } = pluginsConfig
 
   // 使用element ui实现加载提示
   const loading = ELEMENT.Loading.service({

--- a/src/utils/loadTinymce.js
+++ b/src/utils/loadTinymce.js
@@ -1,9 +1,12 @@
 import loadScript from './loadScript'
 import ELEMENT from 'element-ui'
+import pluginsConfig from './pluginsConfig'
 
 let tinymceObj
 
 export default function loadTinymce(cb) {
+  const { tinymceUrl } = pluginsConfig
+
   if (tinymceObj) {
     cb(tinymceObj)
     return
@@ -17,7 +20,7 @@ export default function loadTinymce(cb) {
     background: 'rgba(255, 255, 255, 0.5)'
   })
 
-  loadScript('https://lib.baomitu.com/tinymce/5.3.2/tinymce.min.js', () => {
+  loadScript(tinymceUrl, () => {
     loading.close()
     // eslint-disable-next-line no-undef
     tinymceObj = tinymce

--- a/src/utils/pluginsConfig.js
+++ b/src/utils/pluginsConfig.js
@@ -1,0 +1,11 @@
+const CDN = 'https://lib.baomitu.com/'
+
+function splicingPluginUrl(PluginName, version, fileName) {
+  return `${CDN}${PluginName}/${version}/${fileName}`
+}
+
+export default {
+  beautifierUrl: splicingPluginUrl('js-beautify', '1.13.5', 'beautifier.min.js'),
+  monacoEditorUrl: splicingPluginUrl('monaco-editor', '0.19.3', 'min/vs'),
+  tinymceUrl: splicingPluginUrl('tinymce', '5.3.2', 'tinymce.min.js')
+}


### PR DESCRIPTION
修复因 js-beautify cdn 链接（[https://lib.baomitu.com/js-beautify/1.10.2/beautifier.min.js](https://lib.baomitu.com/js-beautify/1.10.2/beautifier.min.js)）已丢失，导致项目运行报错问题

添加 `/src/utils/pluginsConfig.js`文件，统一管理 cdn 路径。