### PR TITLE
fix:修复cdn 2.13.2有问题回退一个版本cdn

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -76,11 +76,11 @@
       }
     }
   </style>
-  <link href="https://lib.baomitu.com/element-ui/2.13.2/theme-chalk/index.css" rel="stylesheet">
+  <link href="https://lib.baomitu.com/element-ui/2.13.1/theme-chalk/index.css" rel="stylesheet">
   <link href="https://lib.baomitu.com/monaco-editor/0.19.3/min/vs/editor/editor.main.css" rel="stylesheet">
   <script src="https://lib.baomitu.com/vue/2.6.11/vue<%= process.env.NODE_ENV === 'production' ? '.min' : ''%>.js"></script>
   <script src="https://lib.baomitu.com/vue-router/3.1.3/vue-router.min.js"></script>
-  <script src="https://lib.baomitu.com/element-ui/2.13.2/index.js"></script>
+  <script src="https://lib.baomitu.com/element-ui/2.13.1/index.js"></script>
 </head>
 
 <body>

--- a/public/preview.html
+++ b/public/preview.html
@@ -6,10 +6,10 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>form-generator-preview</title>
-    <link href="https://lib.baomitu.com/element-ui/2.13.2/theme-chalk/index.css" rel="stylesheet">
+    <link href="https://lib.baomitu.com/element-ui/2.13.1/theme-chalk/index.css" rel="stylesheet">
     <script src="https://lib.baomitu.com/vue/2.6.11/vue.min.js"></script>
     <script src="https://lib.baomitu.com/vue-router/3.1.3/vue-router.min.js"></script>
-    <script src="https://lib.baomitu.com/element-ui/2.13.2/index.js"></script>
+    <script src="https://lib.baomitu.com/element-ui/2.13.1/index.js"></script>
     <style>
       body{
         margin: 0;


### PR DESCRIPTION
问题描述：预览版本报错
<img width="637" alt="image" src="https://user-images.githubusercontent.com/47852997/184269728-466c4aca-7a4a-4c03-a8ac-e7023bb2b45b.png">
启动的时候也报错，element 地址访问正常，回退到2.13.1正常