### PR TITLE
formConf数据从db中获取时bug修复:查看json无效

### DIFF
--- a/src/views/index/Home.vue
+++ b/src/views/index/Home.vue
@@ -355,8 +355,8 @@ export default {
     },
     AssembleFormData() {
       this.formData = {
-        fields: deepClone(this.drawingList),
-        ...this.formConf
+        ...this.formConf,
+        fields: deepClone(this.drawingList)
       }
     },
     generate(data) {


### PR DESCRIPTION
formConf数据从db中获取时bug修复:查看json无效
1: 打开官方demo https://mrhj.gitee.io/form-generator/#/
2: 点击"查看json"
  然后控制台执行:  localStorage.formConf = JSON.stringify(复制的JSON对象)
3:刷新页面,之后修改表单配置,点击"查看json"会发现没有变动
